### PR TITLE
Fix: print and equality op in `rmqamqpt_basicconsume.cpp`

### DIFF
--- a/src/rmq/rmqamqpt/rmqamqpt_basicconsume.cpp
+++ b/src/rmq/rmqamqpt/rmqamqpt_basicconsume.cpp
@@ -134,11 +134,9 @@ bool operator==(const BasicConsume& lhs, const BasicConsume& rhs)
     return (&lhs == &rhs) ||
            (lhs.queue() == rhs.queue() &&
             lhs.consumerTag() == rhs.consumerTag() &&
-            lhs.noLocal() == rhs.noLocal() &&
-            lhs.noAck() == rhs.noAck() &&
+            lhs.noLocal() == rhs.noLocal() && lhs.noAck() == rhs.noAck() &&
             lhs.exclusive() == rhs.exclusive() &&
-            lhs.noWait() == rhs.noWait() &&
-            lhs.arguments() == rhs.arguments());
+            lhs.noWait() == rhs.noWait() && lhs.arguments() == rhs.arguments());
 }
 
 } // namespace rmqamqpt

--- a/src/rmq/rmqamqpt/rmqamqpt_basicconsume.cpp
+++ b/src/rmq/rmqamqpt/rmqamqpt_basicconsume.cpp
@@ -121,8 +121,9 @@ void BasicConsume::encode(Writer& output, const BasicConsume& consume)
 bsl::ostream& operator<<(bsl::ostream& os, const BasicConsume& consume)
 {
     return os << "BasicConsume: [ queue: " << consume.queue()
-              << ", consumer-tag: " << consume.consumerTag() << ", no-local"
-              << consume.noLocal() << ", no-ack: " << consume.noAck()
+              << ", consumer-tag: " << consume.consumerTag()
+              << ", no-local: " << consume.noLocal()
+              << ", no-ack: " << consume.noAck()
               << ", exclusive: " << consume.exclusive()
               << ", no-wait: " << consume.noWait()
               << ", arguments: " << consume.arguments() << "]";
@@ -133,8 +134,10 @@ bool operator==(const BasicConsume& lhs, const BasicConsume& rhs)
     return (&lhs == &rhs) ||
            (lhs.queue() == rhs.queue() &&
             lhs.consumerTag() == rhs.consumerTag() &&
-            lhs.noLocal() == rhs.noLocal() && lhs.noAck() == rhs.noAck() &&
+            lhs.noLocal() == rhs.noLocal() &&
+            lhs.noAck() == rhs.noAck() &&
             lhs.exclusive() == rhs.exclusive() &&
+            lhs.noWait() == rhs.noWait() &&
             lhs.arguments() == rhs.arguments());
 }
 


### PR DESCRIPTION
1. `", no-local"` -> `", no-local: "`
2. Added missing check in equality operator `lhs.noWait() == rhs.noWait()`
3. Reformatted, so 1 statement per line.

**Upd**: clang asked to revert 1 statement per line.