### PR TITLE
Fix: handle not sufficient buffer size to decode in `rmqamqpt_basicde…

### DIFF
--- a/src/rmq/rmqamqpt/rmqamqpt_basicdeliver.cpp
+++ b/src/rmq/rmqamqpt/rmqamqpt_basicdeliver.cpp
@@ -65,6 +65,7 @@ bool BasicDeliver::decode(BasicDeliver* deliver,
         BALL_LOG_ERROR
             << "Not enough data to decode BasicDeliver frame: available "
             << buffer.available();
+        return false;
     }
     deliver->d_deliveryTag = buffer.copy<bdlb::BigEndianUint64>();
     deliver->d_redelivered = buffer.copy<bool>();


### PR DESCRIPTION
The `if` condition doesn't have return when error observed:
https://github.com/bloomberg/rmqcpp/blob/becec1737669dbebb0a108e9dd0244b294951633/src/rmq/rmqamqpt/rmqamqpt_basicdeliver.cpp#L63-L70

And we just try to decode uint64 and bool from the buffer after this if, using `copy`.

Without this fix the code should crash somewhere near this assert I think:
https://github.com/bloomberg/rmqcpp/blob/becec1737669dbebb0a108e9dd0244b294951633/src/rmq/rmqamqpt/rmqamqpt_buffer.h#L72