### PR TITLE
Make find_package work for rmqcpp

### DIFF
--- a/src/rmq/CMakeLists.txt
+++ b/src/rmq/CMakeLists.txt
@@ -23,13 +23,17 @@ endif()
 
 target_compile_definitions(rmq PRIVATE USES_LIBRMQ_EXPERIMENTAL_FEATURES)
 
-target_include_directories(rmq PUBLIC rmqt rmqp rmqa)
+target_include_directories(rmq PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rmqt>)
+target_include_directories(rmq PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rmqp>)
+target_include_directories(rmq PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/rmqa>)
+
 
 file(GLOB RMQ_PUBLIC_HEADERS rmqa/*h rmqp/*h rmqt/*h)
 set_target_properties(rmq PROPERTIES PUBLIC_HEADER "${RMQ_PUBLIC_HEADERS}")
 
 install(
     TARGETS rmq
+    EXPORT rmqcppTargets
     ARCHIVE
         DESTINATION ${CMAKE_INSTALL_LIBDIR}
         COMPONENT librmq-dev
@@ -37,6 +41,17 @@ install(
         DESTINATION include
         COMPONENT librmq-dev
 )
+
+install(EXPORT rmqcppTargets 
+        FILE rmqcppTargets.cmake 
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp 
+        NAMESPACE rmqcpp::)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in 
+                              "${CMAKE_CURRENT_BINARY_DIR}/rmqcppConfig.cmake"
+                              INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp) 
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rmqcppConfig.cmake" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp)
 
 # Emit some metadata required internally
 set(RMQ_PC_DEP_NAMES bsl bdl bal openssl)

--- a/src/rmq/Config.cmake.in
+++ b/src/rmq/Config.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+if(NOT TARGET rmqcpp)
+    foreach(dep bal;OpenSSL;ZLIB)
+        find_package(${dep})
+    endforeach()
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/rmqcppTargets.cmake")
+
+check_required_components(rmqcpp)


### PR DESCRIPTION
### Problem statement
Make `find_package(rmqcpp REQUIRED)` work for applications installing rmqcpp using a package manager like vcpkg.

### Proposed changes
- Remove absolute paths, export `rmqcppTargets.cmake` and `rmqcppConfig.cmake` [generated using the `Config.cmake.in`] files.   
- Tested in an example application that builds `rmqperftest` with a local vcpkg registry overlay with a `rmqcpp` port to install `rmqcpp`. 
- Reference cmake.in file used by bde-tools: https://github.com/bloomberg/bde-tools/blob/main/BdeBuildSystem/support/uorConfig.cmake.in
- Relevant cmake docs - https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html