### PR TITLE
rm lib64 vs lib sizeof void ptr check

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,12 +5,6 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 find_package(GTest REQUIRED)
 
-if( CMAKE_SIZEOF_VOID_P EQUAL 8 )
-    set(BDE_PACKAGE_SEARCH_PATH "share/bde;lib64/cmake")
-else()
-    set(BDE_PACKAGE_SEARCH_PATH "share/bde;lib/cmake")
-endif()
-
 # BDE-required subpackages
 find_package(bal REQUIRED)
 


### PR DESCRIPTION
Remove extraneous cmake code - could be left from a bad rebase 