### PR TITLE
Use bsl::memcpy to fix strict aliasing errors

### DIFF
--- a/src/rmq/rmqamqpt/rmqamqpt_types.cpp
+++ b/src/rmq/rmqamqpt/rmqamqpt_types.cpp
@@ -368,15 +368,17 @@ class FieldValueEncoder {
     }
     void operator()(float val) const
     {
-        const bsl::uint32_t temp =
-            *reinterpret_cast<const bsl::uint32_t*>(&val);
+        bsl::uint32_t temp;
+        bsl::memcpy(&temp, &val, sizeof(val));
+
         Types::write(output, FieldValue::FLOAT);
         Types::write(output, bdlb::BigEndianUint32::make(temp));
     }
     void operator()(double val) const
     {
-        const bsl::uint64_t temp =
-            *reinterpret_cast<const bsl::uint64_t*>(&val);
+        bsl::uint64_t temp;
+        bsl::memcpy(&temp, &val, sizeof(val));
+
         Types::write(output, FieldValue::DOUBLE);
         Types::write(output, bdlb::BigEndianUint64::make(temp));
     }


### PR DESCRIPTION
### Problem statement
While building with vcpkg on `linux x86_64`, we get errors due to strict aliasing not being complied with - as mentioned in https://github.com/microsoft/vcpkg/pull/34797. 

```
error: dereferencing type-punned pointer will break strict-aliasing rules [-Werror=strict-aliasing]
  379 |             *reinterpret_cast<const bsl::uint64_t*>(&val); 
```

### Proposed changes
We use `bsl::memcpy` instead. 