### PR TITLE
Refactor framer test to fix unused variable warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-variable)
+    add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "SunPro")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-Wall -Wextra -Wpedantic)
+    add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-variable)
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "SunPro")

--- a/src/tests/rmqamqp/rmqamqp_framer.t.cpp
+++ b/src/tests/rmqamqp/rmqamqp_framer.t.cpp
@@ -61,8 +61,6 @@ class ContentDecodeTests : public ::testing::Test {
         using namespace boost::iostreams;
 
         const size_t encodedPayloadSize = contentHeader.encodedSize();
-        const size_t encodedFrameSize =
-            rmqamqpt::Frame::calculateFrameSize(encodedPayloadSize);
 
         bsl::shared_ptr<bsl::vector<uint8_t> > data =
             bsl::make_shared<bsl::vector<uint8_t> >();
@@ -76,7 +74,8 @@ class ContentDecodeTests : public ::testing::Test {
         rmqamqpt::ContentHeader::encode(writer, contentHeader);
         rmqamqpt::Types::write(writer, rmqamqpt::Constants::FRAME_END);
 
-        assert(data->size() == encodedFrameSize);
+        assert(data->size() ==
+               rmqamqpt::Frame::calculateFrameSize(encodedPayloadSize));
 
         return rmqamqpt::Frame(frameType, channel, data);
     }


### PR DESCRIPTION
### Problem statement
Building with `-Wall -Werror` on linux was giving a `-Werror=ununsed-variable` 

### Proposed changes
Changed to directly check value in assert 

This passes the build for consuming from vcpkg to make the port in https://github.com/microsoft/vcpkg/pull/34797 work. 
