### PR TITLE
Fix include guard of rmqa_connectionstring

### DIFF
--- a/src/rmq/rmqa/rmqa_connectionstring.h
+++ b/src/rmq/rmqa/rmqa_connectionstring.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef INCLUDED_RMQA_CONNECTIONMONITOR
-#define INCLUDED_RMQA_CONNECTIONMONITOR
+#ifndef INCLUDED_RMQA_CONNECTIONSTRING
+#define INCLUDED_RMQA_CONNECTIONSTRING
 
 #include <rmqt_vhostinfo.h>
 


### PR DESCRIPTION
This include guard is wrong, which can cause issues when trying to use the two headers rmqa_connectionstring.h and rmqa_connectionmonitor.h in the same TU.
