### PR TITLE
Adds resume functionality

### DIFF
--- a/docs/consumer-state-diagram.md
+++ b/docs/consumer-state-diagram.md
@@ -1,0 +1,11 @@
+# Consumer states
+
+The diagram shows the state changes based on the Broker messages we receive.
+
+## `CANCELLING_BUT_RESUMING`
+
+New state `CANCELLING_BUT_RESUMING` was added to support resume after cancellation. 
+
+- calling `resume()` in a `CANCELLING` state sets the state to `CANCELLING_BUT_RESUMING` which will enable consumer restart
+
+- previously cancelled consumer would be restarted after `resume()` call

--- a/docs/consumer-state-diagram.md
+++ b/docs/consumer-state-diagram.md
@@ -9,3 +9,5 @@ New state `CANCELLING_BUT_RESUMING` was added to support resume after cancellati
 - calling `resume()` in a `CANCELLING` state sets the state to `CANCELLING_BUT_RESUMING` which will enable consumer restart
 
 - previously cancelled consumer would be restarted after `resume()` call
+
+![image](https://github.com/mvrsss/rmqcpp/assets/60746841/54b025ee-3d7a-48de-bbcf-97ba00abf76b)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,4 +4,5 @@ if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "SunPro") AND NOT (CMAKE_CXX_COMPILER_ID 
     # The examples don't need to work on these platforms
     add_subdirectory(helloworld)
     add_subdirectory(topology)
+    add_subdirectory(resume)
 endif()

--- a/examples/resume/CMakeLists.txt
+++ b/examples/resume/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(bsl REQUIRED)
+
+add_executable(resume_consumer
+    resume.m.cpp
+)
+
+target_link_libraries(resume_consumer PUBLIC
+    rmq
+    bsl
+)

--- a/examples/resume/README.md
+++ b/examples/resume/README.md
@@ -1,0 +1,1 @@
+New state CANCELLING_BUT_RESUMING was added to support resume after cancellation

--- a/examples/resume/README.md
+++ b/examples/resume/README.md
@@ -1,1 +1,0 @@
-New state CANCELLING_BUT_RESUMING was added to support resume after cancellation

--- a/examples/resume/resume.m.cpp
+++ b/examples/resume/resume.m.cpp
@@ -1,0 +1,217 @@
+#include <rmqa_connectionstring.h>
+#include <rmqa_consumer.h>
+#include <rmqa_producer.h>
+#include <rmqa_rabbitcontext.h>
+#include <rmqa_topology.h>
+#include <rmqa_vhost.h>
+#include <rmqp_producer.h>
+#include <rmqt_confirmresponse.h>
+#include <rmqt_exchange.h>
+#include <rmqt_message.h>
+#include <rmqt_result.h>
+#include <rmqt_vhostinfo.h>
+
+#include <ball_severityutil.h>
+#include <ball_streamobserver.h>
+
+#include <bsl_iostream.h>
+#include <bsl_memory.h>
+#include <bsl_optional.h>
+#include <bsl_vector.h>
+#include <bsls_atomic.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace BloombergLP;
+using namespace std::chrono_literals;
+
+namespace {
+BALL_LOG_SET_NAMESPACE_CATEGORY("RESUME.CONSUMER")
+
+bsls::AtomicInt consumedCount;
+} // namespace
+
+void configLog(ball::Severity::Level level)
+{
+    static ball::LoggerManagerConfiguration configuration;
+    static bsl::shared_ptr<ball::StreamObserver> loggingObserver =
+        bsl::make_shared<ball::StreamObserver>(&bsl::cout);
+
+    configuration.setDefaultThresholdLevelsIfValid(level);
+
+    static ball::LoggerManagerScopedGuard guard(configuration);
+    ball::LoggerManager::singleton().registerObserver(loggingObserver,
+                                                      "stdout");
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 2) {
+        std::cerr << "USAGE: " << argv[0] << " <amqp uri>\n";
+        return 1;
+    }
+
+    configLog(ball::Severity::e_INFO);
+    rmqa::RabbitContext rabbit;
+
+    bsl::optional<rmqt::VHostInfo> vhostInfo =
+        rmqa::ConnectionString::parse(argv[1]);
+
+    if (!vhostInfo) {
+        std::cerr << "Failed to parse connection string: " << argv[1] << "\n";
+        return 1;
+    }
+
+    // Returns immediately, setup performed on a different thread
+    bsl::shared_ptr<rmqa::VHost> vhost = rabbit.createVHostConnection(
+        "Sample code for a producer", // Connecion Name Visible in management UI
+        vhostInfo.value());
+
+    // How many messages can be awaiting confirmation before `send` blocks
+    const uint16_t maxOutstandingConfirms = 10;
+
+    rmqa::Topology topology;
+    rmqt::ExchangeHandle exch = topology.addExchange("exchange");
+    rmqt::QueueHandle queue   = topology.addQueue("queue1");
+
+    topology.bind(exch, queue, "routing_key");
+
+    rmqt::Result<rmqa::Producer> producerResult =
+        vhost->createProducer(topology, exch, maxOutstandingConfirms);
+    if (!producerResult) {
+        // A fatal error such as `exch` not being present in `topology`
+        // A disconnection, or  will never permanently fail an operation
+        std::cerr << "Error creating connection: " << producerResult.error()
+                  << "\n";
+        return 1;
+    }
+
+    bsl::shared_ptr<rmqa::Producer> producer = producerResult.value();
+
+    bsl::vector<uint8_t> messageVector = {5, 3, 1};
+
+    // `send` will block until a confirm is received if the
+    // `maxOutstandingConfirms` limit is reached
+
+    uint8_t i = 0;
+    while (i++ < 10) {
+        messageVector.push_back(i);
+        rmqt::Message message(
+            bsl::make_shared<bsl::vector<uint8_t> >(messageVector));
+        const rmqp::Producer::SendStatus sendResult = producer->send(
+            message,
+            "routing_key",
+            [](const rmqt::Message& message,
+               const bsl::string& routingKey,
+               const rmqt::ConfirmResponse& response) {
+                // https://www.rabbitmq.com/confirms.html#when-publishes-are-confirmed
+                if (response.status() == rmqt::ConfirmResponse::ACK) {
+                    // Message is now guaranteed to be safe with the broker.
+                    // Now is the time to reply to the request, commit the
+                    // database transaction, or ack the RabbitMQ message which
+                    // triggered this publish
+                }
+                else {
+                    // Send error response, rollback transaction, nack message
+                    // and/or raise an alarm for investigation - your message is
+                    // not delivered to all (or perhaps any) of the queues it
+                    // was intended for.
+                    std::cerr << "Message not confirmed: " << message.guid()
+                              << " for routing key " << routingKey << " "
+                              << response << "\n";
+                }
+            });
+
+        if (sendResult != rmqp::Producer::SENDING) {
+            if (sendResult == rmqp::Producer::DUPLICATE) {
+                std::cerr
+                    << "Failed to send message: " << message.guid()
+                    << " because an identical GUID is already outstanding\n";
+            }
+            else {
+                std::cerr << "Unknown send failure for message: "
+                          << message.guid() << "\n";
+            }
+            return 1;
+        }
+    }
+
+    rmqt::Result<rmqa::Consumer> consumerResult = vhost->createConsumer(
+        topology,
+        queue,
+        [](rmqp::MessageGuard& messageGuard) {
+            std::this_thread::sleep_for(2000ms);
+            messageGuard.ack();
+            ++consumedCount;
+            // std::cout << messageGuard.message() << std::endl;
+        },              // Consumer callback invoked on each message
+        "consumer-1.0", // Consumer Label (shows in Management UI)
+        10              // prefetch count
+    );
+
+    if (!consumerResult) {
+        return -1;
+    }
+
+    bsl::shared_ptr<rmqa::Consumer> consumer = consumerResult.value();
+
+    // Wait for consumer to start consuming
+    std::this_thread::sleep_for(10000ms);
+    std::cout << "Number of messages consumed before cancelling: "
+              << consumedCount << "\n";
+    consumer->cancel();
+
+    consumer->resume();
+    // Wait for consumer to consume messages after resuming
+    std::this_thread::sleep_for(10000ms);
+
+    while (i++ < 40) {
+        messageVector.push_back(i);
+        rmqt::Message message(
+            bsl::make_shared<bsl::vector<uint8_t> >(messageVector));
+        const rmqp::Producer::SendStatus sendResult = producer->send(
+            message,
+            "routing_key",
+            [](const rmqt::Message& message,
+               const bsl::string& routingKey,
+               const rmqt::ConfirmResponse& response) {
+                // https://www.rabbitmq.com/confirms.html#when-publishes-are-confirmed
+                if (response.status() == rmqt::ConfirmResponse::ACK) {
+                    // Message is now guaranteed to be safe with the broker.
+                    // Now is the time to reply to the request, commit the
+                    // database transaction, or ack the RabbitMQ message which
+                    // triggered this publish
+                }
+                else {
+                    // Send error response, rollback transaction, nack message
+                    // and/or raise an alarm for investigation - your message is
+                    // not delivered to all (or perhaps any) of the queues it
+                    // was intended for.
+                    std::cerr << "Message not confirmed: " << message.guid()
+                              << " for routing key " << routingKey << " "
+                              << response << "\n";
+                }
+            });
+
+        if (sendResult != rmqp::Producer::SENDING) {
+            if (sendResult == rmqp::Producer::DUPLICATE) {
+                std::cerr
+                    << "Failed to send message: " << message.guid()
+                    << " because an identical GUID is already outstanding\n";
+            }
+            else {
+                std::cerr << "Unknown send failure for message: "
+                          << message.guid() << "\n";
+            }
+            return 1;
+        }
+    }
+
+    std::cout << "Total number of messages consumed: " << consumedCount;
+
+    // placeholder to keep channel open while resuming
+    uint16_t placeholder = 0;
+    std::cin >> placeholder;
+}

--- a/src/rmq/rmqa/rmqa_consumer.h
+++ b/src/rmq/rmqa/rmqa_consumer.h
@@ -52,7 +52,14 @@ class Consumer {
     /// \brief Tells the broker to stop delivering messages to this consumer.
     /// it's still possible to nack/ack messages from callbacks after cancel is
     /// called
-    void cancel();
+    rmqt::Result<>
+    cancel(const bsls::TimeInterval& timeout = bsls::TimeInterval(0));
+
+    /// \brief Tells the broker to restart consuming after cancelling the
+    /// consumer. Cancelled consumer will not be destroyed, but restarted with
+    /// the same consumer tag.
+    rmqt::Result<>
+    resume(const bsls::TimeInterval& timeout = bsls::TimeInterval(0));
 
     /// \brief Tells the broker to stop delivering messages to this consumer.
     /// \param timeout   How long to wait for all delivered (unacked) messages

--- a/src/rmq/rmqa/rmqa_consumerimpl.cpp
+++ b/src/rmq/rmqa/rmqa_consumerimpl.cpp
@@ -146,6 +146,12 @@ rmqt::Future<> ConsumerImpl::drain()
         bdlf::BindUtil::bind(&rmqamqp::ReceiveChannel::drain, d_channel)));
 }
 
+rmqt::Future<> ConsumerImpl::resume()
+{
+    return rmqt::FutureUtil::flatten<void>(d_eventLoop.postF<rmqt::Future<> >(
+        bdlf::BindUtil::bind(&rmqamqp::ReceiveChannel::resume, d_channel)));
+}
+
 rmqt::Result<> ConsumerImpl::cancelAndDrain(const bsls::TimeInterval& timeout)
 {
     bsl::function<rmqt::Future<>()> fn =

--- a/src/rmq/rmqa/rmqa_consumerimpl.h
+++ b/src/rmq/rmqa/rmqa_consumerimpl.h
@@ -88,6 +88,8 @@ class ConsumerImpl : public rmqp::Consumer,
     /// messages
     rmqt::Future<> drain() BSLS_KEYWORD_OVERRIDE;
 
+    rmqt::Future<> resume() BSLS_KEYWORD_OVERRIDE;
+
     rmqt::Result<>
     cancelAndDrain(const bsls::TimeInterval& timeout) BSLS_KEYWORD_OVERRIDE;
 

--- a/src/rmq/rmqamqp/rmqamqp_consumer.h
+++ b/src/rmq/rmqamqp/rmqamqp_consumer.h
@@ -47,7 +47,14 @@ class Consumer {
     typedef bsl::function<void(const rmqt::Message&, const rmqt::Envelope&)>
         MessageCallback;
 
-    enum State { NOT_CONSUMING, STARTING, CONSUMING, CANCELLING, CANCELLED };
+    enum State {
+        NOT_CONSUMING,
+        STARTING,
+        CONSUMING,
+        CANCELLING_BUT_RESUMING,
+        CANCELLING,
+        CANCELLED
+    };
     bsl::optional<rmqamqpt::BasicMethod>
     consume(const rmqt::ConsumerConfig& consumerConfig);
     bsl::optional<rmqamqpt::BasicMethod> consumeOk();
@@ -72,6 +79,7 @@ class Consumer {
     bool isCancelling() const;
 
     void reset();
+    void resume();
 
     const bsl::string& consumerTag() const;
     const bsl::string& queueName() const;

--- a/src/rmq/rmqamqp/rmqamqp_receivechannel.h
+++ b/src/rmq/rmqamqp/rmqamqp_receivechannel.h
@@ -103,6 +103,8 @@ class ReceiveChannel : public Channel {
     /// immediately with an error result
     virtual rmqt::Future<> drain();
 
+    virtual rmqt::Future<> resume();
+
     size_t inFlight() const BSLS_KEYWORD_OVERRIDE
     {
         return d_messageStore.count();
@@ -154,6 +156,7 @@ class ReceiveChannel : public Channel {
     MultipleAckHandler d_multipleAckHandler;
     bslma::ManagedPtr<rmqt::Future<>::Pair> d_cancelFuturePair;
     bslma::ManagedPtr<rmqt::Future<>::Maker> d_drainFuture;
+    bslma::ManagedPtr<rmqt::Future<>::Pair> d_resumeFuturePair;
 };
 
 } // namespace rmqamqp

--- a/src/rmq/rmqp/rmqp_consumer.h
+++ b/src/rmq/rmqp/rmqp_consumer.h
@@ -56,6 +56,8 @@ class Consumer {
     /// send any more messages.
     virtual rmqt::Future<> cancel() = 0;
 
+    virtual rmqt::Future<> resume() = 0;
+
     /// \brief Can only be called (successfully) once the Consumer has been
     /// cancelled, returns a future which resolves when all outstanding acks
     /// have been sent to the server, \note: this relies on the consumer code

--- a/src/rmqtestmocks/rmqtestmocks_mockconsumer.h
+++ b/src/rmqtestmocks/rmqtestmocks_mockconsumer.h
@@ -49,6 +49,7 @@ class MockConsumer : public rmqp::Consumer {
     static rmqt::Future<rmqp::Consumer> errorAsync();
 
     MOCK_METHOD0(cancel, rmqt::Future<>());
+    MOCK_METHOD0(resume, rmqt::Future<>());
     MOCK_METHOD0(drain, rmqt::Future<>());
     MOCK_METHOD1(cancelAndDrain, rmqt::Result<>(const bsls::TimeInterval&));
     MOCK_METHOD2(updateTopology,

--- a/src/tests/rmqa/rmqa_consumerimpl.t.cpp
+++ b/src/tests/rmqa/rmqa_consumerimpl.t.cpp
@@ -300,6 +300,30 @@ TEST_P(ConsumerImplTests, Drain)
     EXPECT_THAT(result, Eq(true));
 }
 
+TEST_P(ConsumerImplTests, Resume)
+{
+    rmqt::Future<>::Pair fakeyResumeFuture = rmqt::Future<>::make();
+
+    bsl::shared_ptr<rmqa::ConsumerImpl> consumer =
+        d_factory->create(d_channel,
+                          bsl::ref(d_queue),
+                          d_callback,
+                          d_consumerTag,
+                          bsl::ref(d_threadPool),
+                          bsl::ref(d_eventLoop),
+                          d_ackQueue);
+
+    EXPECT_CALL(*d_channel, resume())
+        .WillOnce(Return(fakeyResumeFuture.second));
+    rmqt::Future<> future = consumer->resume();
+    bool result           = future.tryResult();
+    EXPECT_THAT(result, Eq(false));
+    fakeyResumeFuture.first(rmqt::Result<>());
+    result = future.tryResult();
+
+    EXPECT_THAT(result, Eq(true));
+}
+
 TEST_P(ConsumerImplTests, UpdateCallback)
 {
     bsl::shared_ptr<rmqtestutil::MockUpdateReceiveChannel>

--- a/src/tests/rmqtestutil/rmqtestutil_mockchannel.t.h
+++ b/src/tests/rmqtestutil/rmqtestutil_mockchannel.t.h
@@ -127,6 +127,7 @@ class MockReceiveChannel : public rmqamqp::ReceiveChannel {
                                 const bsl::string&));
     MOCK_METHOD0(consumeAckBatchFromQueue, void());
     MOCK_METHOD0(cancel, rmqt::Future<>());
+    MOCK_METHOD0(resume, rmqt::Future<>());
     MOCK_METHOD0(drain, rmqt::Future<>());
     MOCK_CONST_METHOD1(getMessagesOlderThan,
                        rmqamqp::MessageStore<rmqt::Message>::MessageList(


### PR DESCRIPTION
### Problem statement:
- Previously, there was no resume() function that would restart the consumer after cancellation.

### Proposed changes:
- Implements resume() function
- Adds CANCELLING_BUT_RESUMING state to the consumer
- CANCELLING_BUT_RESUMING state is added to support prefetch update in the future
- Supports timeout in cancel and resume functions

![image](https://github.com/bloomberg/rmqcpp/assets/60746841/fecb8e1c-4f29-4d4c-a2ef-b2d39e7dde10)

