### PR TITLE
Replace bsl::string with std to fix build error

### DIFF
--- a/src/tests/rmqio/rmqio_asioresolver.t.cpp
+++ b/src/tests/rmqio/rmqio_asioresolver.t.cpp
@@ -89,8 +89,8 @@ TEST_F(ResolverTests, badresolve)
 
 TEST_F(ResolverTests, ShufflesResolverResults)
 {
-    bsl::string host = "host";
-    bsl::string port = "port";
+    std::string host = "host";
+    std::string port = "port";
     typedef boost::asio::ip::basic_resolver_entry<boost::asio::ip::tcp>
         entry_type;
 
@@ -131,8 +131,8 @@ TEST_F(ResolverTests, ShufflesResolverResults)
 
 TEST_F(ResolverTests, NoShuffleDoesNotReorderResolverResults)
 {
-    bsl::string host = "host";
-    bsl::string port = "port";
+    std::string host = "host";
+    std::string port = "port";
     typedef boost::asio::ip::basic_resolver_entry<boost::asio::ip::tcp>
         entry_type;
 


### PR DESCRIPTION
### Problem Statement
Build was failing with the errors in `rmqio_asioresolver.t.cpp`

``` 
error: no matching constructor for initialization of 'entry_type' (aka 'basic_resolver_entry<boost::asio::ip::tcp>')
        entries.push_back(entry_type(endpoint, host, port));
                          ^          ~~~~~~~~~~~~~~~~~~~~
/boost/asio/ip/basic_resolver_entry.hpp:53:3: note: candidate constructor not viable: no known conversion from 'bsl::string' (aka 'basic_string<char>') to 'boost::asio::string_view' (aka 'basic_string_view<char>') for 2nd argument
  basic_resolver_entry(const endpoint_type& ep,
  ^
```

### Proposed changes
Changing to std::string should fix build
