### PR TITLE
Implemented the onSuccess() callback

### DIFF
--- a/src/rmq/rmqa/rmqa_connectionimpl.h
+++ b/src/rmq/rmqa/rmqa_connectionimpl.h
@@ -60,6 +60,7 @@ class ConnectionImpl : public rmqp::Connection,
          rmqio::EventLoop& eventLoop,
          bdlmt::ThreadPool& threadpool,
          const rmqt::ErrorCallback& errorCb,
+         const rmqt::SuccessCallback& successCb,
          const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
          const rmqt::Tunables& tunables,
          const bsl::shared_ptr<rmqa::ConsumerImpl::Factory>& consumerFactory,
@@ -97,6 +98,7 @@ class ConnectionImpl : public rmqp::Connection,
         rmqio::EventLoop& loop,
         bdlmt::ThreadPool& threadPool,
         const rmqt::ErrorCallback& errorCb,
+        const rmqt::SuccessCallback& successCb,
         const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
         const rmqt::Tunables& tunables,
         const bsl::shared_ptr<rmqa::ConsumerImpl::Factory>& consumerFactory,
@@ -112,6 +114,7 @@ class ConnectionImpl : public rmqp::Connection,
     bdlmt::ThreadPool& d_threadPool;
     rmqio::EventLoop& d_eventLoop;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
     bsl::shared_ptr<rmqt::Endpoint> d_endpoint;
     ///< Held for logging
     bsl::shared_ptr<rmqa::ConsumerImpl::Factory> d_consumerFactory;

--- a/src/rmq/rmqa/rmqa_rabbitcontextimpl.h
+++ b/src/rmq/rmqa/rmqa_rabbitcontextimpl.h
@@ -75,6 +75,7 @@ class RabbitContextImpl : public rmqp::RabbitContext {
     bdlmt::ThreadPool* d_threadPool;
     bslma::ManagedPtr<bdlmt::ThreadPool> d_hostedThreadPool;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
     bsl::shared_ptr<ConnectionMonitor> d_connectionMonitor;
     bslma::ManagedPtr<rmqamqp::Connection::Factory> d_connectionFactory;
     rmqt::Tunables d_tunables;

--- a/src/rmq/rmqa/rmqa_rabbitcontextoptions.cpp
+++ b/src/rmq/rmqa/rmqa_rabbitcontextoptions.cpp
@@ -85,6 +85,13 @@ RabbitContextOptions::setErrorCallback(const rmqt::ErrorCallback& errorCallback)
     return *this;
 }
 
+RabbitContextOptions&
+RabbitContextOptions::setSuccessCallback(const rmqt::SuccessCallback& successCallback)
+{
+    d_onSuccess = successCallback;
+    return *this;
+}
+
 RabbitContextOptions& RabbitContextOptions::setMetricPublisher(
     const bsl::shared_ptr<rmqp::MetricPublisher>& metricPublisher)
 {

--- a/src/rmq/rmqa/rmqa_rabbitcontextoptions.h
+++ b/src/rmq/rmqa/rmqa_rabbitcontextoptions.h
@@ -78,6 +78,10 @@ class RabbitContextOptions {
     RabbitContextOptions&
     setErrorCallback(const rmqt::ErrorCallback& errorCallback);
 
+    /// \param successCallback function will be called when channel or
+    /// connection is restored
+    RabbitContextOptions& setSuccessCallback(const rmqt::SuccessCallback& successCallback);
+
     /// \param name name of client property to set
     /// \param value value of client property
     /// NOTE: The following properties are set by default and can be
@@ -144,6 +148,8 @@ class RabbitContextOptions {
 
     const rmqt::ErrorCallback& errorCallback() const { return d_onError; }
 
+    const rmqt::SuccessCallback& successCallback() const { return d_onSuccess; }
+
     const rmqt::FieldTable& clientProperties() const
     {
         return d_clientProperties;
@@ -184,6 +190,7 @@ class RabbitContextOptions {
     static const int DEFAULT_MESSAGE_PROCESSING_TIMEOUT = 60;
     bdlmt::ThreadPool* d_threadpool;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
     bsl::shared_ptr<rmqp::MetricPublisher> d_metricPublisher;
     rmqt::FieldTable d_clientProperties;
     bsls::TimeInterval d_messageProcessingTimeout;

--- a/src/rmq/rmqamqp/rmqamqp_connection.cpp
+++ b/src/rmq/rmqamqp/rmqamqp_connection.cpp
@@ -983,11 +983,13 @@ Connection::Factory::Factory(
     const bsl::shared_ptr<rmqio::Resolver>& resolver,
     const bsl::shared_ptr<rmqio::TimerFactory>& timerFactory,
     const rmqt::ErrorCallback& errorCb,
+    const rmqt::SuccessCallback& successCb,
     const bsl::shared_ptr<rmqp::MetricPublisher>& metricPublisher,
     const bsl::shared_ptr<ConnectionMonitor>& connectionMonitor,
     const rmqt::FieldTable& clientProperties,
     const bsl::optional<bsls::TimeInterval>& connectionErrorThreshold)
 : d_errorCb(errorCb)
+, d_successCb(successCb)
 , d_clientProperties(clientProperties)
 , d_metricPublisher(metricPublisher)
 , d_resolver(resolver)
@@ -1026,11 +1028,13 @@ bsl::shared_ptr<rmqio::RetryHandler> Connection::Factory::newRetryHandler()
                      bsl::make_shared<rmqio::ConnectionRetryHandler>(
                          d_timerFactory,
                          d_errorCb,
+                         d_successCb,
                          bsl::make_shared<rmqio::BackoffLevelRetryStrategy>(),
                          *d_connectionErrorThreshold))
                : bsl::make_shared<rmqio::RetryHandler>(
                      d_timerFactory,
                      d_errorCb,
+                     d_successCb,
                      bsl::make_shared<rmqio::BackoffLevelRetryStrategy>());
 }
 

--- a/src/rmq/rmqamqp/rmqamqp_connection.h
+++ b/src/rmq/rmqamqp/rmqamqp_connection.h
@@ -311,6 +311,7 @@ class Connection::Factory {
     Factory(const bsl::shared_ptr<rmqio::Resolver>& resolver,
             const bsl::shared_ptr<rmqio::TimerFactory>& timerFactory,
             const rmqt::ErrorCallback& errorCb,
+            const rmqt::SuccessCallback& successCb,
             const bsl::shared_ptr<rmqp::MetricPublisher>& metricPublisher,
             const bsl::shared_ptr<ConnectionMonitor>& connectionMonitor,
             const rmqt::FieldTable& clientProperties,
@@ -333,6 +334,7 @@ class Connection::Factory {
     Factory& operator=(const Factory&) BSLS_KEYWORD_DELETED;
 
     const rmqt::ErrorCallback d_errorCb;
+    const rmqt::SuccessCallback d_successCb;
     const rmqt::FieldTable d_clientProperties;
     const bsl::shared_ptr<rmqp::MetricPublisher> d_metricPublisher;
     const bsl::shared_ptr<rmqio::Resolver> d_resolver;

--- a/src/rmq/rmqio/rmqio_connectionretryhandler.cpp
+++ b/src/rmq/rmqio/rmqio_connectionretryhandler.cpp
@@ -38,9 +38,10 @@ BALL_LOG_SET_NAMESPACE_CATEGORY("RMQIO.CONNECTIONRETRYHANDLER")
 ConnectionRetryHandler::ConnectionRetryHandler(
     const bsl::shared_ptr<TimerFactory>& timerFactory,
     const rmqt::ErrorCallback& errorCb,
+    const rmqt::SuccessCallback& successCb,
     const bsl::shared_ptr<RetryStrategy>& retryStrategy,
     const bsls::TimeInterval& errorThreshold)
-: RetryHandler(timerFactory, errorCb, retryStrategy)
+: RetryHandler(timerFactory, errorCb, successCb, retryStrategy)
 , d_errorThreshold(errorThreshold)
 , d_errorSince()
 
@@ -57,6 +58,7 @@ void ConnectionRetryHandler::success()
 {
     RetryHandler::success();
     d_errorSince.reset();
+    successCallback()();
 }
 
 void ConnectionRetryHandler::evaluateErrorThreshold()

--- a/src/rmq/rmqio/rmqio_connectionretryhandler.h
+++ b/src/rmq/rmqio/rmqio_connectionretryhandler.h
@@ -42,6 +42,7 @@ class ConnectionRetryHandler : public RetryHandler {
     ///                         there has been no success within
     ConnectionRetryHandler(const bsl::shared_ptr<TimerFactory>& timerFactory,
                            const rmqt::ErrorCallback& errorCb,
+                           const rmqt::SuccessCallback& successCb,
                            const bsl::shared_ptr<RetryStrategy>& retryStrategy,
                            const bsls::TimeInterval& errorThreshold);
 

--- a/src/rmq/rmqio/rmqio_retryhandler.cpp
+++ b/src/rmq/rmqio/rmqio_retryhandler.cpp
@@ -32,6 +32,7 @@ BALL_LOG_SET_NAMESPACE_CATEGORY("RMQIO.RETRYHANDLER")
 
 RetryHandler::RetryHandler(const bsl::shared_ptr<TimerFactory>& timerFactory,
                            const rmqt::ErrorCallback& errorCb,
+                           const rmqt::SuccessCallback& successCb,
                            const bsl::shared_ptr<RetryStrategy>& retryStrategy)
 : d_sleepTimer(timerFactory->createWithCallback(
       bdlf::BindUtil::bind(&RetryHandler::handleRetry,
@@ -40,6 +41,7 @@ RetryHandler::RetryHandler(const bsl::shared_ptr<TimerFactory>& timerFactory,
 , d_retryStrategy(retryStrategy)
 , d_retryCallback()
 , d_onError(errorCb)
+, d_onSuccess(successCb)
 {
 }
 

--- a/src/rmq/rmqio/rmqio_retryhandler.h
+++ b/src/rmq/rmqio/rmqio_retryhandler.h
@@ -42,6 +42,7 @@ class RetryHandler {
     /// \param retryStrategy    the retry strategy to use
     RetryHandler(const bsl::shared_ptr<TimerFactory>& timerFactory,
                  const rmqt::ErrorCallback& errorCb,
+                 const rmqt::SuccessCallback& successCb,
                  const bsl::shared_ptr<RetryStrategy>& retryStrategy);
 
     virtual ~RetryHandler() {}
@@ -58,6 +59,11 @@ class RetryHandler {
         return d_onError;
     }
 
+    virtual const rmqt::SuccessCallback& successCallback() const
+    {
+      return d_onSuccess;
+    }
+
   private:
     RetryHandler(const RetryHandler&) BSLS_KEYWORD_DELETED;
     RetryHandler& operator=(const RetryHandler&) BSLS_KEYWORD_DELETED;
@@ -70,6 +76,7 @@ class RetryHandler {
     bsl::shared_ptr<RetryStrategy> d_retryStrategy;
     RetryCallback d_retryCallback;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
 };
 
 } // namespace rmqio

--- a/src/rmq/rmqt/rmqt_result.h
+++ b/src/rmq/rmqt/rmqt_result.h
@@ -167,6 +167,10 @@ typedef bsl::function<void(const bsl::string& errorText, int errorCode)>
 /// The normal execution of program will not be stopped.
 /// The callback will only bubble up the error details to the client.
 
+typedef bsl::function<void()> SuccessCallback;
+/// SuccessCallback function will be called on client thread,
+/// whenever channel or connection will be restored.
+
 } // namespace rmqt
 } // namespace BloombergLP
 

--- a/src/tests/rmqa/rmqa_connectionimpl.t.cpp
+++ b/src/tests/rmqa/rmqa_connectionimpl.t.cpp
@@ -116,6 +116,7 @@ class ConnectionTests : public ::testing::Test {
     NiceMock<rmqtestutil::MockEventLoop> d_eventLoop;
     bsl::shared_ptr<rmqamqp::HeartbeatManager> d_hb;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
     bsl::shared_ptr<rmqio::RetryHandler> d_retryHandler;
     bsl::shared_ptr<rmqamqp::ChannelFactory> d_channelFactory;
     bsl::shared_ptr<rmqtestutil::MockMetricPublisher> d_metricPublisher;
@@ -140,9 +141,11 @@ class ConnectionTests : public ::testing::Test {
     , d_eventLoop(d_timerFactory)
     , d_hb(new rmqamqp::HeartbeatManagerImpl(d_timerFactory))
     , d_onError()
+    , d_onSuccess()
     , d_retryHandler(bsl::make_shared<rmqio::RetryHandler>(
           d_timerFactory,
           d_onError,
+          d_onSuccess,
           bsl::make_shared<rmqio::BackoffLevelRetryStrategy>()))
     , d_channelFactory(bsl::make_shared<rmqamqp::ChannelFactory>())
     , d_metricPublisher(bsl::make_shared<rmqtestutil::MockMetricPublisher>())
@@ -200,6 +203,7 @@ TEST_F(ConnectionTests, BreathingTest)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,
@@ -218,6 +222,7 @@ TEST_F(ConnectionTests, CreateSyncSuccess)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,
@@ -254,6 +259,7 @@ TEST_F(ConnectionTests, CreateConsumer)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,
@@ -277,6 +283,7 @@ TEST_F(ConnectionTests, CreateProducer)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,
@@ -298,6 +305,7 @@ TEST_F(ConnectionTests, CloseCreatesTimerAndInvokesClose)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,
@@ -326,6 +334,7 @@ TEST_F(ConnectionTests, GracefulCloseHitsTimeoutAndSuccessfulCloseRace)
                                    d_eventLoop,
                                    d_threadPool,
                                    d_onError,
+                                   d_onSuccess,
                                    d_endpoint,
                                    d_tunables,
                                    d_consumerFactory,

--- a/src/tests/rmqamqp/rmqamqp_connection.t.cpp
+++ b/src/tests/rmqamqp/rmqamqp_connection.t.cpp
@@ -65,6 +65,8 @@ const char* TEST_VHOST = "vhostname";
 
 void noOpOnError(const bsl::string&, int) {}
 
+void noOpOnSuccess() {}
+
 void noopCloseHandler() {}
 
 void gracefulCloseHandler(bool& invoked) { invoked = true; }
@@ -323,6 +325,7 @@ class ConnectionFactory : public rmqamqp::Connection::Factory {
         const bsl::shared_ptr<rmqio::Resolver>& resolver,
         const bsl::shared_ptr<rmqio::TimerFactory>& timerFactory,
         const rmqt::ErrorCallback& errorCb,
+        const rmqt::SuccessCallback& successCb,
         const bsl::shared_ptr<rmqp::MetricPublisher>& metricPublisher,
         const rmqt::FieldTable& clientProperties,
         const bsl::shared_ptr<rmqio::RetryHandler>& retryHandler,
@@ -331,6 +334,7 @@ class ConnectionFactory : public rmqamqp::Connection::Factory {
     : rmqamqp::Connection::Factory(resolver,
                                    timerFactory,
                                    errorCb,
+                                   successCb,
                                    metricPublisher,
                                    bsl::make_shared<MockConnectionMonitor>(),
                                    clientProperties,
@@ -361,6 +365,7 @@ class ConnectionTests : public ::testing::Test {
   public:
     ReplayFrame d_replayFrame;
     rmqt::ErrorCallback d_errorCallback;
+    rmqt::SuccessCallback d_successCallback;
     bsl::shared_ptr<rmqtestutil::MockResolver> d_resolver;
     bsl::shared_ptr<rmqtestutil::MockRetryHandler> d_retryHandler;
     bsl::shared_ptr<rmqtestutil::MockTimerFactory> d_timerFactory;
@@ -391,6 +396,7 @@ class ConnectionTests : public ::testing::Test {
     ConnectionTests()
     : d_replayFrame()
     , d_errorCallback(noOpOnError)
+    , d_successCallback(noOpOnSuccess)
     , d_resolver(bsl::make_shared<rmqtestutil::MockResolver>())
     , d_retryHandler(bsl::make_shared<rmqtestutil::MockRetryHandler>())
     , d_timerFactory(bsl::make_shared<rmqtestutil::MockTimerFactory>())
@@ -407,6 +413,7 @@ class ConnectionTests : public ::testing::Test {
     , d_factory(bsl::make_shared<ConnectionFactory>(d_resolver,
                                                     d_timerFactory,
                                                     d_errorCallback,
+                                                    d_successCallback,
                                                     d_metricPublisher,
                                                     d_clientProperties,
                                                     d_retryHandler,
@@ -684,6 +691,7 @@ TEST_F(ConnectionTests, ClientProperties)
     d_factory = bsl::make_shared<ConnectionFactory>(d_resolver,
                                                     d_timerFactory,
                                                     d_errorCallback,
+                                                    d_successCallback,
                                                     d_metricPublisher,
                                                     overriddenClientProperties,
                                                     d_retryHandler,
@@ -722,6 +730,7 @@ TEST_F(ConnectionTests, ClientPropertiesCantOverrideReservedOnes)
     d_factory = bsl::make_shared<ConnectionFactory>(d_resolver,
                                                     d_timerFactory,
                                                     d_errorCallback,
+                                                    d_successCallback,
                                                     d_metricPublisher,
                                                     overriddenClientProperties,
                                                     d_retryHandler,

--- a/src/tests/rmqio/rmqio_connectionretryhandler.t.cpp
+++ b/src/tests/rmqio/rmqio_connectionretryhandler.t.cpp
@@ -56,7 +56,9 @@ class ConnectionRetryHandlerTests : public ::testing::Test {
         d_retryStrategy;
     StrictMock<testing::MockFunction<void(const bsl::string&, int)> >
         d_onErrorCallback;
+    StrictMock<testing::MockFunction<void()>> d_onSuccessCallback;
     rmqt::ErrorCallback d_onError;
+    rmqt::SuccessCallback d_onSuccess;
     bdlt::CurrentTime::CurrentTimeCallback d_oldTimeCb;
 
     ConnectionRetryHandlerTests()
@@ -68,6 +70,9 @@ class ConnectionRetryHandlerTests : public ::testing::Test {
           &d_onErrorCallback,
           bdlf::PlaceHolders::_1,
           bdlf::PlaceHolders::_2))
+    , d_onSuccess(bdlf::BindUtil::bind(
+        &testing::MockFunction<void()>::Call,
+        &d_onSuccessCallback))
     , d_oldTimeCb(bdlt::CurrentTime::setCurrentTimeCallback(fixedTimeCb<0, 0>))
     {
     }
@@ -90,13 +95,13 @@ class ConnectionRetryHandlerTests : public ::testing::Test {
 TEST_F(ConnectionRetryHandlerTests, Breathing)
 {
     ConnectionRetryHandler ConnectionRetryHandler(
-        d_timerFactory, d_onError, d_retryStrategy, bsls::TimeInterval(2));
+        d_timerFactory, d_onError, d_onSuccess, d_retryStrategy, bsls::TimeInterval(2));
 }
 
 TEST_F(ConnectionRetryHandlerTests, RetryWithoutWait)
 {
     ConnectionRetryHandler ConnectionRetryHandler(
-        d_timerFactory, d_onError, d_retryStrategy, bsls::TimeInterval(2));
+        d_timerFactory, d_onError, d_onSuccess, d_retryStrategy, bsls::TimeInterval(2));
     int numRetries = 0;
 
     retryExpectations();
@@ -114,6 +119,7 @@ TEST_F(ConnectionRetryHandlerTests, MultipleRetry)
     ConnectionRetryHandler ConnectionRetryHandler(
         d_timerFactory,
         d_onError,
+        d_onSuccess,
         d_retryStrategy,
         bsls::TimeInterval(2)); /* 3 */
     int numRetries = 0;
@@ -138,6 +144,7 @@ TEST_F(ConnectionRetryHandlerTests, MultipleRetryWithWait)
     ConnectionRetryHandler ConnectionRetryHandler(
         d_timerFactory,
         d_onError,
+        d_onSuccess,
         d_retryStrategy,
         bsls::TimeInterval(2)); /* 1,20 */
     int numRetries = 0;
@@ -164,6 +171,7 @@ TEST_F(ConnectionRetryHandlerTests, NoPrematureRetry)
     ConnectionRetryHandler ConnectionRetryHandler(
         d_timerFactory,
         d_onError,
+        d_onSuccess,
         d_retryStrategy,
         bsls::TimeInterval(2)); /* 1,20 */
     int numRetries = 0;
@@ -191,6 +199,7 @@ TEST_F(ConnectionRetryHandlerTests, MultipleRetryWithWaitLimit)
     ConnectionRetryHandler ConnectionRetryHandler(
         d_timerFactory,
         d_onError,
+        d_onSuccess,
         d_retryStrategy,
         bsls::TimeInterval(2)); /* 1,20, 21 */
     int numRetries = 0;
@@ -228,7 +237,7 @@ TEST_F(ConnectionRetryHandlerTests, RetryIsNotCalledAfterBeingDestroyed)
 
     {
         ConnectionRetryHandler ConnectionRetryHandler(
-            d_timerFactory, d_onError, d_retryStrategy, bsls::TimeInterval(2));
+            d_timerFactory, d_onError, d_onSuccess, d_retryStrategy, bsls::TimeInterval(2));
 
         retryExpectations();
         ConnectionRetryHandler.retry(rmqtestutil::CallCount(&numRetries));
@@ -253,7 +262,7 @@ TEST_F(ConnectionRetryHandlerTests,
 
     {
         ConnectionRetryHandler ConnectionRetryHandler(
-            d_timerFactory, d_onError, d_retryStrategy, bsls::TimeInterval(2));
+            d_timerFactory, d_onError, d_onSuccess, d_retryStrategy, bsls::TimeInterval(2));
 
         retryExpectations();
         ConnectionRetryHandler.retry(rmqtestutil::CallCount(&numRetries));
@@ -281,7 +290,7 @@ TEST_F(ConnectionRetryHandlerTests,
     int numRetries = 0;
 
     ConnectionRetryHandler ConnectionRetryHandler(
-        d_timerFactory, d_onError, d_retryStrategy, bsls::TimeInterval(2));
+        d_timerFactory, d_onError, d_onSuccess, d_retryStrategy, bsls::TimeInterval(2));
 
     retryExpectations();
     ConnectionRetryHandler.retry(rmqtestutil::CallCount(&numRetries));

--- a/src/tests/rmqtestutil/rmqtestutil_mockretryhandler.t.h
+++ b/src/tests/rmqtestutil/rmqtestutil_mockretryhandler.t.h
@@ -34,6 +34,7 @@ class MockRetryHandler : public rmqio::RetryHandler {
     explicit MockRetryHandler()
     : rmqio::RetryHandler(bsl::make_shared<rmqtestutil::MockTimerFactory>(),
                           rmqt::ErrorCallback(),
+                          rmqt::SuccessCallback(),
                           bsl::make_shared<rmqtestutil::MockRetryStrategy>())
     {
     }


### PR DESCRIPTION
### Problem statement
Current implementation of rmqcpp library only provides a callback when the connection is broken. There is no callback which allows to detect when connection is restored to provide a more flexible way to monitor the connection state.

### Proposed changes
The onSuccess() callback is raised on connection restore.

### Remaining work
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
