### PR TITLE
Fix installation location for cmake files.

### DIFF
--- a/src/rmq/CMakeLists.txt
+++ b/src/rmq/CMakeLists.txt
@@ -44,14 +44,14 @@ install(
 
 install(EXPORT rmqcppTargets 
         FILE rmqcppTargets.cmake 
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp 
+        DESTINATION share/rmqcpp 
         NAMESPACE rmqcpp::)
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in 
                               "${CMAKE_CURRENT_BINARY_DIR}/rmqcppConfig.cmake"
-                              INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp) 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rmqcppConfig.cmake" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/rmqcpp)
+                              INSTALL_DESTINATION share/rmqcpp) 
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/rmqcppConfig.cmake" DESTINATION share/rmqcpp)
 
 # Emit some metadata required internally
 set(RMQ_PC_DEP_NAMES bsl bdl bal openssl)


### PR DESCRIPTION
The installation location of the cmake files is now correct if the prefix is overwritten at installation time.

### Problem statement
When installing rmqcpp with cmake --install . --prefix  some/dir everything is installed to some/dir except for the cmake files. 

### Proposed changes
Use relative Paths for the cmake files.
