### PR TITLE
Clean up depenedencies

### DIFF
--- a/src/rmq/rmqamqp/rmqamqp_framer.cpp
+++ b/src/rmq/rmqamqp/rmqamqp_framer.cpp
@@ -21,9 +21,6 @@
 #include <rmqamqpt_method.h>
 #include <rmqamqpt_types.h>
 
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/stream.hpp>
-
 #include <ball_log.h>
 #include <bdlb_bigendian.h>
 
@@ -209,7 +206,6 @@ void Framer::makeMethodFrame(rmqamqpt::Frame* frame,
                              uint16_t channel,
                              const rmqamqpt::Method& method)
 {
-    using namespace boost::iostreams;
 
     const size_t encodedPayloadSize = method.encodedSize();
     const size_t encodedFrameSize =
@@ -233,7 +229,6 @@ rmqamqpt::Frame Framer::makeContentBodyFrame(const uint8_t* message,
                                              const size_t encodedPayloadSize,
                                              uint16_t channel)
 {
-    using namespace boost::iostreams;
 
     bsl::shared_ptr<bsl::vector<uint8_t> > data =
         bsl::make_shared<bsl::vector<uint8_t> >();
@@ -251,7 +246,6 @@ rmqamqpt::Frame Framer::makeContentBodyFrame(const uint8_t* message,
 rmqamqpt::Frame Framer::makeContentHeaderFrame(const rmqt::Message& message,
                                                uint16_t channel)
 {
-    using namespace boost::iostreams;
 
     const rmqamqpt::ContentHeader header(rmqamqpt::Constants::BASIC, message);
 
@@ -274,7 +268,6 @@ rmqamqpt::Frame Framer::makeContentHeaderFrame(const rmqt::Message& message,
 
 rmqamqpt::Frame Framer::makeHeartbeatFrame()
 {
-    using namespace boost::iostreams;
 
     const bsl::shared_ptr<bsl::vector<uint8_t> > data =
         bsl::make_shared<bsl::vector<uint8_t> >();

--- a/src/rmq/rmqamqpt/rmqamqpt_method.cpp
+++ b/src/rmq/rmqamqpt/rmqamqpt_method.cpp
@@ -17,8 +17,6 @@
 
 #include <rmqamqpt_types.h>
 
-#include <boost/iostreams/stream.hpp>
-
 #include <ball_log.h>
 #include <bdlb_bigendian.h>
 #include <bsl_cstdint.h>

--- a/src/rmq/rmqio/CMakeLists.txt
+++ b/src/rmq/rmqio/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(rmqio PUBLIC
     bal
     rmqamqpt
     rmqt
+    Boost::boost
 )
 
 if( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "SunPro" )

--- a/src/rmq/rmqio/rmqio_asioconnection.cpp
+++ b/src/rmq/rmqio/rmqio_asioconnection.cpp
@@ -20,7 +20,6 @@
 
 #include <boost/asio.hpp>
 #include <fcntl.h>
-#include <openssl/err.h>
 
 #include <ball_log.h>
 #include <bdlf_bind.h>

--- a/src/tests/rmqamqp/rmqamqp_framer.t.cpp
+++ b/src/tests/rmqamqp/rmqamqp_framer.t.cpp
@@ -21,9 +21,6 @@
 #include <rmqio_serializedframe.h>
 #include <rmqt_fieldvalue.h>
 
-#include <boost/iostreams/device/back_inserter.hpp>
-#include <boost/iostreams/stream.hpp>
-
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -58,7 +55,6 @@ class ContentDecodeTests : public ::testing::Test {
                     uint16_t channel,
                     const rmqamqpt::ContentHeader& contentHeader)
     {
-        using namespace boost::iostreams;
 
         const size_t encodedPayloadSize = contentHeader.encodedSize();
 
@@ -83,7 +79,6 @@ class ContentDecodeTests : public ::testing::Test {
                                   uint16_t channel,
                                   const rmqamqpt::ContentBody& contentBody)
     {
-        using namespace boost::iostreams;
 
         const size_t encodedPayloadSize = contentBody.dataLength();
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
     "version": "1.0.0",
     "dependencies": [
       "boost-asio",
-      "boost-iostreams",
       "openssl",
       "gtest",
       "bde"


### PR DESCRIPTION
### Problem statement
Boost.Iostreams was not actually used.
The CMake dependencies to ASIO and its dependencies have not been established.
### Proposed changes
Remove Boost.Iostreams includes and vcpkg dependencies.
Add `target_link_library` to the header-only target `Boost::boost`.
