### PR TITLE
Add connection name in error callback message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ clean:
 	rm -rf $(BUILD_FOLDER)
 
 docker-setup:
-	cd $(SRC_FOLDER)/dockerfiles && docker-compose build --pull 
+	cd $(SRC_FOLDER)/dockerfiles && docker compose build --pull 
 
 docker-build:
-	cd $(SRC_FOLDER)/dockerfiles && docker-compose run dev make full
+	cd $(SRC_FOLDER)/dockerfiles && docker compose run dev make full
 
 docker-test:
-	cd $(SRC_FOLDER)/dockerfiles && docker-compose run dev make full-test
+	cd $(SRC_FOLDER)/dockerfiles && docker compose run dev make full-test
 
 docker-shell:
-	cd $(SRC_FOLDER)/dockerfiles && docker-compose run dev
+	cd $(SRC_FOLDER)/dockerfiles && docker compose run dev
 
 .PHONY: build init unit integration clean full full-test

--- a/src/rmq/rmqamqp/rmqamqp_connection.cpp
+++ b/src/rmq/rmqamqp/rmqamqp_connection.cpp
@@ -630,11 +630,10 @@ class Connection::ConnectionMethodProcessor {
         conn.sendConnectionCloseOk();
 
         if (closeMethod.classId() || closeMethod.methodId()) {
-            conn.d_retryHandler->errorCallback()("Connection=" + 
-                                                     conn.d_connectionName +
-                                                     " Connection error " +
-                                                     closeMethod.replyText(),
-                                                 closeMethod.replyCode());
+            conn.d_retryHandler->errorCallback()(
+                "Connection=" + conn.d_connectionName + " Connection error " +
+                    closeMethod.replyText(),
+                closeMethod.replyCode());
         }
     }
 

--- a/src/rmq/rmqamqp/rmqamqp_connection.cpp
+++ b/src/rmq/rmqamqp/rmqamqp_connection.cpp
@@ -630,7 +630,9 @@ class Connection::ConnectionMethodProcessor {
         conn.sendConnectionCloseOk();
 
         if (closeMethod.classId() || closeMethod.methodId()) {
-            conn.d_retryHandler->errorCallback()("Connection error " +
+            conn.d_retryHandler->errorCallback()("Connection=" + 
+                                                     conn.d_connectionName +
+                                                     " Connection error " +
                                                      closeMethod.replyText(),
                                                  closeMethod.replyCode());
         }


### PR DESCRIPTION
### Problem statement
- In a multi connection setup, error callback from connection.close does not help in distinguishing the connection

### Proposed changes
- Add connection name in error callback message

### Remaining work
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
