### PR TITLE
Add error callback per vhost connection

### DIFF
--- a/examples/rmqperftest/rmqperftest_runner.cpp
+++ b/examples/rmqperftest/rmqperftest_runner.cpp
@@ -86,7 +86,7 @@ class ConfirmCallback {
 
     void operator()(const rmqt::Message&,
                     const bsl::string&,
-                    const rmqt::ConfirmResponse&){};
+                    const rmqt::ConfirmResponse&) {};
 };
 
 bsl::string_view queueNameOrRoutingKey(bsl::string_view routingKey,

--- a/src/rmq/rmqa/rmqa_rabbitcontext.cpp
+++ b/src/rmq/rmqa/rmqa_rabbitcontext.cpp
@@ -60,6 +60,19 @@ bsl::shared_ptr<rmqa::VHost> RabbitContext::createVHostConnection(
             .managedPtr()));
 }
 
+bsl::shared_ptr<rmqa::VHost> RabbitContext::createVHostConnection(
+    const bsl::string& userDefinedName,
+    const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
+    const bsl::shared_ptr<rmqt::Credentials>& credentials,
+    const rmqt::ErrorCallback& errorCallback)
+{
+    return bsl::shared_ptr<VHost>(
+        new VHost(d_impl
+                      ->createVHostConnection(
+                          userDefinedName, endpoint, credentials, errorCallback)
+                      .managedPtr()));
+}
+
 bsl::shared_ptr<rmqa::VHost>
 RabbitContext::createVHostConnection(const bsl::string& userDefinedName,
                                      const rmqt::VHostInfo& vhostInfo)

--- a/src/rmq/rmqa/rmqa_rabbitcontext.h
+++ b/src/rmq/rmqa/rmqa_rabbitcontext.h
@@ -80,6 +80,12 @@ class RabbitContext {
         const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
         const bsl::shared_ptr<rmqt::Credentials>& credentials);
 
+    bsl::shared_ptr<VHost>
+    createVHostConnection(const bsl::string& userDefinedName,
+                          const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
+                          const bsl::shared_ptr<rmqt::Credentials>& credentials,
+                          const rmqt::ErrorCallback& errorCallback);
+
     /// \brief Connect to a RabbitMQ broker
     ///
     /// \param vhostInfo identifies the broker to connect to & authentication

--- a/src/rmq/rmqa/rmqa_rabbitcontextimpl.h
+++ b/src/rmq/rmqa/rmqa_rabbitcontextimpl.h
@@ -56,6 +56,12 @@ class RabbitContextImpl : public rmqp::RabbitContext {
 
     bsl::shared_ptr<rmqp::Connection> createVHostConnection(
         const bsl::string& userDefinedName,
+        const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
+        const bsl::shared_ptr<rmqt::Credentials>& credentials,
+        const rmqt::ErrorCallback& errorCallback) BSLS_KEYWORD_OVERRIDE;
+
+    bsl::shared_ptr<rmqp::Connection> createVHostConnection(
+        const bsl::string& userDefinedName,
         const rmqt::VHostInfo& endpoint) BSLS_KEYWORD_OVERRIDE;
 
     rmqt::Future<rmqp::Connection>

--- a/src/rmq/rmqamqp/rmqamqp_channelfactory.h
+++ b/src/rmq/rmqamqp/rmqamqp_channelfactory.h
@@ -36,7 +36,7 @@ namespace rmqamqp {
 
 class ChannelFactory {
   public:
-    virtual ~ChannelFactory(){};
+    virtual ~ChannelFactory() {};
 
     virtual bsl::shared_ptr<ReceiveChannel> createReceiveChannel(
         const rmqt::Topology& topology,

--- a/src/rmq/rmqamqp/rmqamqp_connection.h
+++ b/src/rmq/rmqamqp/rmqamqp_connection.h
@@ -310,7 +310,6 @@ class Connection::Factory {
 
     Factory(const bsl::shared_ptr<rmqio::Resolver>& resolver,
             const bsl::shared_ptr<rmqio::TimerFactory>& timerFactory,
-            const rmqt::ErrorCallback& errorCb,
             const bsl::shared_ptr<rmqp::MetricPublisher>& metricPublisher,
             const bsl::shared_ptr<ConnectionMonitor>& connectionMonitor,
             const rmqt::FieldTable& clientProperties,
@@ -321,10 +320,12 @@ class Connection::Factory {
     virtual bsl::shared_ptr<Connection>
     create(const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
            const bsl::shared_ptr<rmqt::Credentials>& credentials,
+           const rmqt::ErrorCallback& errorCallback,
            const bsl::string& name = "");
 
   protected:
-    virtual bsl::shared_ptr<rmqio::RetryHandler> newRetryHandler();
+    virtual bsl::shared_ptr<rmqio::RetryHandler>
+    newRetryHandler(const rmqt::ErrorCallback& errorCallback);
     virtual bsl::shared_ptr<rmqamqp::HeartbeatManager> newHeartBeatManager();
     virtual bsl::shared_ptr<rmqamqp::ChannelFactory> newChannelFactory();
 
@@ -332,7 +333,6 @@ class Connection::Factory {
     Factory(const Factory&) BSLS_KEYWORD_DELETED;
     Factory& operator=(const Factory&) BSLS_KEYWORD_DELETED;
 
-    const rmqt::ErrorCallback d_errorCb;
     const rmqt::FieldTable d_clientProperties;
     const bsl::shared_ptr<rmqp::MetricPublisher> d_metricPublisher;
     const bsl::shared_ptr<rmqio::Resolver> d_resolver;

--- a/src/rmq/rmqio/rmqio_timer.h
+++ b/src/rmq/rmqio/rmqio_timer.h
@@ -72,7 +72,7 @@ class Timer {
 
 class TimerFactory {
   public:
-    virtual ~TimerFactory(){};
+    virtual ~TimerFactory() {};
 
     /// Creates a timer and initializes its timeout. The timer should be
     /// started by calling start().

--- a/src/rmq/rmqp/rmqp_rabbitcontext.h
+++ b/src/rmq/rmqp/rmqp_rabbitcontext.h
@@ -55,6 +55,12 @@ class RabbitContext {
         const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
         const bsl::shared_ptr<rmqt::Credentials>& credentials) = 0;
 
+    virtual bsl::shared_ptr<Connection>
+    createVHostConnection(const bsl::string& userDefinedName,
+                          const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
+                          const bsl::shared_ptr<rmqt::Credentials>& credentials,
+                          const rmqt::ErrorCallback& errorCallback) = 0;
+
     /// \brief Connect to a RabbitMQ broker
     ///
     /// \param vhostInfo identifies the broker to connect to & authentication

--- a/src/rmq/rmqt/rmqt_credentials.h
+++ b/src/rmq/rmqt/rmqt_credentials.h
@@ -25,7 +25,7 @@ namespace rmqt {
 
 class Credentials {
   public:
-    virtual ~Credentials(){};
+    virtual ~Credentials() {};
     virtual bsl::string formatCredentials()       = 0;
     virtual bsl::string authenticationMechanism() = 0;
 };

--- a/src/rmq/rmqt/rmqt_endpoint.h
+++ b/src/rmq/rmqt/rmqt_endpoint.h
@@ -29,7 +29,7 @@ class SecurityParameters;
 
 class Endpoint {
   public:
-    virtual ~Endpoint(){};
+    virtual ~Endpoint() {};
     virtual bsl::string formatAddress() const = 0;
     virtual bsl::string hostname() const      = 0;
     virtual bsl::string vhost() const         = 0;

--- a/src/rmqtestmocks/rmqtestmocks_mockrabbitcontext.h
+++ b/src/rmqtestmocks/rmqtestmocks_mockrabbitcontext.h
@@ -54,6 +54,13 @@ class MockRabbitContext : public rmqp::RabbitContext {
                      const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
                      const bsl::shared_ptr<rmqt::Credentials>& credentials));
 
+    MOCK_METHOD4(createVHostConnection,
+                 bsl::shared_ptr<rmqp::Connection>(
+                     const bsl::string& userDefinedName,
+                     const bsl::shared_ptr<rmqt::Endpoint>& endpoint,
+                     const bsl::shared_ptr<rmqt::Credentials>& credentials,
+                     const rmqt::ErrorCallback& errorCallback));
+
     MOCK_METHOD2(
         createVHostConnection,
         bsl::shared_ptr<rmqp::Connection>(const bsl::string& userDefinedName,


### PR DESCRIPTION
### Problem statement
- right now error callback is for entire rabbit context, for a multi vhost setup there is no possibility to provide separate error callback

### Proposed changes
- add the possibility to add error callback per vhost when creating the connection. this error callback will take precedence over the one provided by in rabbit context. all now there is a possibility to stop getting error callback for a specific vhost by putting an empty callback during creation of connection

### Remaining work
- [x] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
