### PR TITLE
allow actions bot to write dox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ jobs:
     #Only run for push to main
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to push to gh-pages
     steps:
       - uses: actions/checkout@v3
       - name: Doxygenize


### PR DESCRIPTION
```
remote: Permission to bloomberg/rmqcpp.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/bloomberg/rmqcpp/': The requested URL returned error: 403
```


