### PR TITLE
Fix missing is_same case for char

### DIFF
--- a/src/rmq/rmqamqpt/rmqamqpt_types.h
+++ b/src/rmq/rmqamqpt/rmqamqpt_types.h
@@ -84,6 +84,7 @@ class Types {
 #ifdef BSLS_COMPILERFEATURES_SUPPORT_STATIC_ASSERT
         // Ensure the bytes are always written in big-endian order
         static_assert(bsl::is_same<T, bool>::value ||
+                          bsl::is_same<T, char>::value ||
                           bsl::is_same<T, signed char>::value ||
                           bsl::is_same<T, unsigned char>::value ||
                           bsl::is_same<T, bdlb::BigEndianInt16>::value ||


### PR DESCRIPTION
### Problem statement
`char` is a distinct type from `unsigned char` and `signed char, even though this should be supported.

### Proposed changes
Add an `is_same` check for `char`

### Remaining work
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
