### PR TITLE
Fix tests

### DIFF
--- a/src/tests/rmqamqp/rmqamqp_framer.t.cpp
+++ b/src/tests/rmqamqp/rmqamqp_framer.t.cpp
@@ -24,6 +24,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <bsl_cstring.h>
 #include <bsl_memory.h>
 #include <bsl_vector.h>
 
@@ -115,6 +116,16 @@ class ContentEncodeTests : public ::testing::Test {
     rmqamqp::Framer framer;
     bsl::vector<rmqamqpt::Frame> frames;
 };
+
+bdlb::BigEndianUint64 readBodySize(const rmqamqpt::Frame& frame)
+{
+    bdlb::BigEndianUint64 val;
+    bsl::memcpy(&val,
+                frame.rawData() + rmqamqpt::Frame::frameHeaderSize() + 4,
+                sizeof(val));
+    return val;
+}
+
 } // namespace
 
 TEST(Framer, Heartbeat)
@@ -442,9 +453,8 @@ TEST_F(ContentEncodeTests, ZeroBodySizeDoesNotProduceBodyFrame)
     framer.makeFrames(&frames, 2, rmqamqp::Message(rmqt::Message()));
 
     EXPECT_THAT(frames, SizeIs(1));
-    EXPECT_TRUE(*reinterpret_cast<const bdlb::BigEndianUint64*>(
-                    frames[0].rawData() + rmqamqpt::Frame::frameHeaderSize() +
-                    4) == 0); // body size field inside content header frame
+    EXPECT_TRUE(readBodySize(frames[0]) ==
+                0); // body size field inside content header frame
     EXPECT_THAT(frames[0].payloadLength(),
                 Eq(16)); // Content-header size with delivery mode
 }
@@ -457,10 +467,8 @@ TEST_F(ContentEncodeTests, SmallMessageIsEncodedInOneFrame)
     framer.makeFrames(&frames, 2u, theMessage);
 
     EXPECT_THAT(frames, SizeIs(2));
-    EXPECT_TRUE(
-        *reinterpret_cast<const bdlb::BigEndianUint64*>(
-            frames[0].rawData() + rmqamqpt::Frame::frameHeaderSize() + 4) ==
-        messageBytes); // body size field inside content header frame
+    EXPECT_TRUE(readBodySize(frames[0]) ==
+                messageBytes); // body size field inside content header frame
     EXPECT_THAT(frames[0].payloadLength(),
                 Eq(BYTES_HEADER_WITH_MESSAGEID_DELIVERY_MODE)); // header
     EXPECT_THAT(frames[1].payloadLength(), Eq(messageBytes));   // body frame
@@ -477,10 +485,8 @@ TEST_F(ContentEncodeTests, LargerMessageIsEncodedInTwoFrames)
         rmqamqp::Message(rmqt::Message(
             bsl::make_shared<bsl::vector<uint8_t> >(messageBytes))));
     EXPECT_THAT(frames, SizeIs(3));
-    EXPECT_TRUE(
-        *reinterpret_cast<const bdlb::BigEndianUint64*>(
-            frames[0].rawData() + rmqamqpt::Frame::frameHeaderSize() + 4) ==
-        messageBytes); // body size field inside content header frame
+    EXPECT_TRUE(readBodySize(frames[0]) ==
+                messageBytes); // body size field inside content header frame
     EXPECT_THAT(frames[0].payloadLength(),
                 Eq(BYTES_HEADER_WITH_MESSAGEID_DELIVERY_MODE)); // header
     EXPECT_THAT(frames[1].payloadLength(), Eq(firstFrame));     // body frame 1


### PR DESCRIPTION
### Problem statement
```
    Start 2: rmqamqp_tests
2/7 Test #2: rmqamqp_tests ....................Bus error***Exception:   0.98 sec
```

The unit tests have the above error when running on `Solaris`.

### Proposed changes
Resolves #82

```
*reinterpret_cast<const bdlb::BigEndianUint64*>(
                    frames[0].rawData() + rmqamqpt::Frame::frameHeaderSize() + 4)
```

The Bus error is caused by unaligned memory access. The above code jumps to offset `11` and does a `reinterpret_cast<onst bdlb::BigEndianUint64*>` **but access to this pointer requires 8 byte alignment**.

* ✅ Unaligned memory access on `x86/x86_64` architecture works but has some performance penalties.
* ❌ Unaligned memory access on `sparc` architecture raises `SIGBUS` because aligned access is required.

The fix uses `memcpy` to read the unaligned bytes into a memory location that is 8 byte aligned.

<img width="508" height="270" alt="image" src="https://github.com/user-attachments/assets/ed1fd3c9-cc6b-4aa7-993e-5cbcb56d8938" />

### Remaining work
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
