### PR TITLE
Add virtual destructor to rmqt::VHostInfo

### DIFF
--- a/src/rmq/rmqt/rmqt_vhostinfo.cpp
+++ b/src/rmq/rmqt/rmqt_vhostinfo.cpp
@@ -28,6 +28,8 @@ VHostInfo::VHostInfo(const bsl::shared_ptr<rmqt::Endpoint> endpoint,
 {
 }
 
+VHostInfo::~VHostInfo() {}
+
 bsl::shared_ptr<rmqt::Endpoint> VHostInfo::endpoint() const
 {
     return d_endpoint;

--- a/src/rmq/rmqt/rmqt_vhostinfo.h
+++ b/src/rmq/rmqt/rmqt_vhostinfo.h
@@ -36,6 +36,8 @@ class VHostInfo {
     VHostInfo(const bsl::shared_ptr<rmqt::Endpoint> endpoint,
               const bsl::shared_ptr<rmqt::Credentials> credentials);
 
+    virtual ~VHostInfo();
+
     virtual bsl::shared_ptr<rmqt::Endpoint> endpoint() const;
     virtual bsl::shared_ptr<rmqt::Credentials> credentials() const;
 


### PR DESCRIPTION
### Problem statement

`rmqt::VHostInfo` declares virtual member functions, but didn't have a virtual destructor.

### Proposed changes

Declare the destructor virtual to ensure correct destruction.
