### PR TITLE
Feature/optional tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,12 @@ option(ENABLE_COMPRESSION "Enable zstd compression support" ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
 
-option(rmqcpp_ENABLE_TESTING "Enable testing" ON)
+# Derive the default for enabling testing from the selected vcpkg features
+set(rmqcpp_ENABLE_TESTING_DEFAULT ON)
+if(VCPKG_MANIFEST_MODE AND VCPKG_MANIFEST_NO_DEFAULT_FEATURES AND NOT "tests" IN_LIST VCPKG_MANIFEST_FEATURES)
+    set(rmqcpp_ENABLE_TESTING_DEFAULT OFF)
+endif()
+option(rmqcpp_ENABLE_TESTING "Enable testing (requires GTest)" ${rmqcpp_ENABLE_TESTING_DEFAULT})
 if(rmqcpp_ENABLE_TESTING)
     enable_testing()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 option(ENABLE_COMPRESSION "Enable zstd compression support" ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-enable_testing()
+
+option(rmqcpp_ENABLE_TESTING "Enable testing" ON)
+if(rmqcpp_ENABLE_TESTING)
+    enable_testing()
+endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(rmqperftest)
+if(rmqcpp_ENABLE_TESTING)
+    add_subdirectory(rmqperftest)
+endif()
 
 if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "SunPro") AND NOT (CMAKE_CXX_COMPILER_ID STREQUAL "XL"))
     # The examples don't need to work on these platforms

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,11 +6,15 @@ endif()
 find_package(Boost REQUIRED)
 set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
-find_package(GTest REQUIRED)
+if(rmqcpp_ENABLE_TESTING)
+    find_package(GTest REQUIRED)
+endif()
 
 # BDE-required subpackages
 find_package(bal REQUIRED)
 
 add_subdirectory(rmq)
-add_subdirectory(rmqtestmocks)
-add_subdirectory(tests)
+if(rmqcpp_ENABLE_TESTING)
+    add_subdirectory(rmqtestmocks)
+    add_subdirectory(tests)
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -5,9 +5,19 @@
     "dependencies": [
       "boost-asio",
       "openssl",
-      "gtest",
       "bde",
       "pcre2",
       "zstd"
+    ],
+    "features": {
+      "tests": {
+        "description": "Build the rmqcpp unit and integration tests",
+        "dependencies": [
+          "gtest"
+        ]
+      }
+    },
+    "default-features": [
+      "tests"
     ]
 }


### PR DESCRIPTION
### Problem statement
This PR addresses the inability to build rmqcpp without the tests and the GTest dependency.  This was requested in #69.

### Proposed changes
I introduced a CMake option, `rmqcpp_ENABLE_TESTING` to control the building of tests and finding of GTest in CMake.  From the vcpkg side I moved the `gtest` dependency to a feature that's enabled by default.  To connect the vcpkg side to the CMake side, an additional CMake variable, `rmqcpp_ENABLE_TESTING_DEFAULT`, controls the default value of `rmqcpp_ENABLE_TESTING`.  

If building directly with CMake, the option can be set with `-Drmqcpp_ENABLE_TESTING` when `cmake` is called.  If building with vcpkg manifest mode, these are the different options that can be used:

```
cmake --preset <p>                                            # -> tests ON
cmake --preset <p> -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON    # -> tests OFF
cmake --preset <p> -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON \
                   -DVCPKG_MANIFEST_FEATURES=tests            # -> tests ON 
```

Testing is enabled by default for backwards compatibility.

### Remaining work
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Documentation
