### PR TITLE
Construct SecureEndpoint in ConnectionString::parse

### DIFF
--- a/src/rmq/rmqa/rmqa_connectionstring.cpp
+++ b/src/rmq/rmqa/rmqa_connectionstring.cpp
@@ -16,6 +16,8 @@
 #include <rmqa_connectionstring.h>
 
 #include <rmqt_plaincredentials.h>
+#include <rmqt_secureendpoint.h>
+#include <rmqt_securityparameters.h>
 #include <rmqt_simpleendpoint.h>
 #include <rmqt_vhostinfo.h>
 
@@ -29,7 +31,9 @@
 namespace BloombergLP {
 namespace rmqa {
 
-bsl::optional<rmqt::VHostInfo> ConnectionString::parse(bsl::string_view uri)
+bsl::optional<rmqt::VHostInfo> ConnectionString::parse(
+    bsl::string_view uri,
+    const bsl::shared_ptr<rmqt::SecurityParameters>& securityParameters)
 {
     bsl::string_view scheme   = "";
     bsl::string_view username = "guest";
@@ -68,8 +72,22 @@ bsl::optional<rmqt::VHostInfo> ConnectionString::parse(bsl::string_view uri)
         return bsl::optional<rmqt::VHostInfo>();
     }
 
-    bsl::shared_ptr<rmqt::Endpoint> endpoint =
-        bsl::make_shared<rmqt::SimpleEndpoint>(hostname, vhost, portNum16);
+    bsl::shared_ptr<rmqt::Endpoint> endpoint;
+
+    if (scheme == "amqp") {
+        endpoint =
+            bsl::make_shared<rmqt::SimpleEndpoint>(hostname, vhost, portNum16);
+    }
+    else {
+        if (!securityParameters) {
+            return bsl::optional<rmqt::VHostInfo>();
+        }
+
+        endpoint = bsl::make_shared<rmqt::SecureEndpoint>(bsl::string(hostname),
+                                                          bsl::string(vhost),
+                                                          portNum16,
+                                                          securityParameters);
+    }
 
     bsl::shared_ptr<rmqt::Credentials> credentials =
         bsl::make_shared<rmqt::PlainCredentials>(username, password);

--- a/src/rmq/rmqa/rmqa_connectionstring.h
+++ b/src/rmq/rmqa/rmqa_connectionstring.h
@@ -18,10 +18,15 @@
 
 #include <rmqt_vhostinfo.h>
 
+#include <bsl_memory.h>
 #include <bsl_optional.h>
 #include <bsl_string.h>
 
 namespace BloombergLP {
+namespace rmqt {
+class SecurityParameters;
+}
+
 namespace rmqa {
 
 /// \class ConnectionString
@@ -33,7 +38,10 @@ namespace rmqa {
 /// implement proper escape patterns etc.
 class ConnectionString {
   public:
-    static bsl::optional<rmqt::VHostInfo> parse(bsl::string_view uri);
+    static bsl::optional<rmqt::VHostInfo>
+    parse(bsl::string_view uri,
+          const bsl::shared_ptr<rmqt::SecurityParameters>& securityParameters =
+              bsl::shared_ptr<rmqt::SecurityParameters>());
 
     static bool parseParts(bsl::string_view* scheme,
                            bsl::string_view* username,

--- a/src/tests/rmqa/rmqa_connectionstring.t.cpp
+++ b/src/tests/rmqa/rmqa_connectionstring.t.cpp
@@ -15,8 +15,12 @@
 
 #include <rmqa_connectionstring.h>
 
+#include <rmqt_endpoint.h>
+#include <rmqt_securityparameters.h>
+
 #include <rmqtestutil_testsuite.t.h>
 
+#include <bsl_memory.h>
 #include <bsl_string.h>
 
 #include <gmock/gmock.h>
@@ -103,3 +107,47 @@ const ConnectionStringTestCase k_CONN_STRING_TESTS[] = {
 RMQTESTUTIL_TESTSUITE_P(ConnectionStringTests,
                         ConnectionStringPTests,
                         testing::ValuesIn(k_CONN_STRING_TESTS));
+
+TEST(ConnectionStringParse, SecureWithSecurityParameters)
+{
+    const bsl::shared_ptr<rmqt::SecurityParameters> params =
+        bsl::make_shared<rmqt::SecurityParameters>("/path/to/CA.crt");
+
+    const bsl::optional<rmqt::VHostInfo> vhostInfo = ConnectionString::parse(
+        "amqps://adam:password@rabbit1:5671/my-vhost", params);
+
+    ASSERT_TRUE(vhostInfo);
+    EXPECT_THAT(vhostInfo->endpoint()->securityParameters(), Eq(params));
+    EXPECT_THAT(vhostInfo->endpoint()->formatAddress(),
+                Eq("amqps://rabbit1:5671/my-vhost"));
+}
+
+TEST(ConnectionStringParse, SecureWithoutSecurityParameters)
+{
+    EXPECT_FALSE(ConnectionString::parse("amqps://rabbit1:5671/my-vhost"));
+}
+
+TEST(ConnectionStringParse, SimpleWithSecurityParameters)
+{
+    const bsl::shared_ptr<rmqt::SecurityParameters> params =
+        bsl::make_shared<rmqt::SecurityParameters>("/path/to/CA.crt");
+
+    const bsl::optional<rmqt::VHostInfo> vhostInfo =
+        ConnectionString::parse("amqp://adam@rabbit1/my-vhost", params);
+
+    ASSERT_TRUE(vhostInfo);
+    EXPECT_THAT(vhostInfo->endpoint()->securityParameters(), IsNull());
+    EXPECT_THAT(vhostInfo->endpoint()->formatAddress(),
+                Eq("amqp://rabbit1:5672/my-vhost"));
+}
+
+TEST(ConnectionStringParse, SimpleWithoutSecurityParameters)
+{
+    const bsl::optional<rmqt::VHostInfo> vhostInfo =
+        ConnectionString::parse("amqp://adam:password@rabbit1:5672/my-vhost");
+
+    ASSERT_TRUE(vhostInfo);
+    EXPECT_THAT(vhostInfo->endpoint()->securityParameters(), IsNull());
+    EXPECT_THAT(vhostInfo->endpoint()->formatAddress(),
+                Eq("amqp://rabbit1:5672/my-vhost"));
+}


### PR DESCRIPTION
### Problem statement
- `ConnectionString::parse` always constructs a `SimpleEndpoint`

### Proposed changes
- If `ConnectionString::parse` is invoked on an `amqps://` URI, a new null-defaulted parameter is used to make a `SecureEndpoint`
- If the parameter is absent for an `amqps://` URI, validation fails and returns `nullopt`
- No behaviour change for the `amqp://` scheme

### Remaining work
- [x] Unit Tests
- [ ] Integration Tests
- [ ] Documentation